### PR TITLE
chore(ui): fix select item text color

### DIFF
--- a/apps/web/src/components/feature/ApiConfigAccordion.tsx
+++ b/apps/web/src/components/feature/ApiConfigAccordion.tsx
@@ -64,7 +64,7 @@ export function ApiConfigAccordion({
                 <SelectTrigger className="mt-1 bg-zinc-950 border-zinc-800 text-zinc-100">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="bg-zinc-900/70 backdrop-blur-md border-zinc-700">
+                <SelectContent className="bg-zinc-900/70 backdrop-blur-md border-zinc-700 text-white">
                   <SelectItem value="gitee">Gitee AI</SelectItem>
                   <SelectItem value="hf-zimage">HF Z-Image Turbo</SelectItem>
                   <SelectItem value="hf-qwen">HF Qwen Image</SelectItem>


### PR DESCRIPTION
This PR fixes an issue where the text color inside the <SelectItem> components
was too dark on a dark background, making the options unreadable.

Changes included:
- Added `text-white` to SelectItem elements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text color contrast in dropdown menus for better readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->