### PR TITLE
feat(flow): integrate multi-provider API support / 集成多提供商API支持

### DIFF
--- a/apps/web/src/components/flow/FloatingInput.tsx
+++ b/apps/web/src/components/flow/FloatingInput.tsx
@@ -2,7 +2,10 @@ import { useState, useEffect, useCallback } from "react";
 import { ImageIcon, Sparkles, Zap, RefreshCw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ASPECT_RATIOS } from "@/lib/constants";
-import { loadFlowInputSettings, saveFlowInputSettings } from "@/lib/flow-storage";
+import {
+  loadFlowInputSettings,
+  saveFlowInputSettings,
+} from "@/lib/flow-storage";
 
 interface FloatingInputProps {
   onSubmit: (config: {
@@ -12,9 +15,13 @@ interface FloatingInputProps {
     batchCount: number;
     seed: number;
   }) => void;
+  providerLabel: string;
 }
 
-export default function FloatingInput({ onSubmit }: FloatingInputProps) {
+export default function FloatingInput({
+  onSubmit,
+  providerLabel,
+}: FloatingInputProps) {
   const [aspectRatioIndex, setAspectRatioIndex] = useState(0);
   const [resolutionIndex, setResolutionIndex] = useState(0); // 0=1K, 1=2K - independent of aspect ratio
   const [prompt, setPrompt] = useState("");
@@ -67,7 +74,6 @@ export default function FloatingInput({ onSubmit }: FloatingInputProps) {
     });
   };
 
-
   const cycleAspectRatio = () => {
     setAspectRatioIndex((prev) => (prev + 1) % ASPECT_RATIOS.length);
     // Don't reset resolutionIndex - keep it independent
@@ -103,7 +109,9 @@ export default function FloatingInput({ onSubmit }: FloatingInputProps) {
             onClick={cycleResolution}
             className="bg-zinc-800 text-zinc-400 hover:bg-zinc-700 rounded-full px-3 py-0.5 text-xs font-normal cursor-pointer"
           >
-            {currentResolution.w >= 2048 || currentResolution.h >= 2048 ? "2K" : "1K"}
+            {currentResolution.w >= 2048 || currentResolution.h >= 2048
+              ? "2K"
+              : "1K"}
           </Badge>
           <Badge
             variant="secondary"
@@ -138,7 +146,7 @@ export default function FloatingInput({ onSubmit }: FloatingInputProps) {
               <span className="text-zinc-500 font-medium">图片生成模式</span>
               <span className="h-3 w-px bg-zinc-700 mx-1"></span>
               <Sparkles size={14} className="text-yellow-500" />
-              <span>Gitee AI</span>
+              <span>{providerLabel}</span>
             </div>
           </div>
 

--- a/apps/web/src/lib/crypto.ts
+++ b/apps/web/src/lib/crypto.ts
@@ -1,40 +1,130 @@
-const STORAGE_KEY = 'z-image-api-key-encrypted'
+const STORAGE_KEY = "z-image-api-key-encrypted";
+const HF_TOKEN_STORAGE_KEY = "hfToken";
 
 async function getKey(): Promise<CryptoKey> {
-  const fingerprint = [navigator.userAgent, navigator.language, screen.width, screen.height].join('|')
-  const encoder = new TextEncoder()
-  const keyMaterial = await crypto.subtle.importKey('raw', encoder.encode(fingerprint), 'PBKDF2', false, ['deriveKey'])
-  return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt: encoder.encode('z-image-salt'), iterations: 100000, hash: 'SHA-256' },
-    keyMaterial,
-    { name: 'AES-GCM', length: 256 },
+  const fingerprint = [
+    navigator.userAgent,
+    navigator.language,
+    screen.width,
+    screen.height,
+  ].join("|");
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(fingerprint),
+    "PBKDF2",
     false,
-    ['encrypt', 'decrypt']
-  )
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: encoder.encode("z-image-salt"),
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
+}
+
+async function getHfTokenKey(usage: "encrypt" | "decrypt"): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(navigator.userAgent),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt: encoder.encode("hf-salt"),
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    [usage],
+  );
 }
 
 export async function encryptAndStore(apiKey: string): Promise<void> {
   if (!apiKey) {
-    localStorage.removeItem(STORAGE_KEY)
-    return
+    localStorage.removeItem(STORAGE_KEY);
+    return;
   }
-  const key = await getKey()
-  const iv = crypto.getRandomValues(new Uint8Array(12))
-  const encrypted = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, new TextEncoder().encode(apiKey))
-  const data = JSON.stringify({ iv: Array.from(iv), data: Array.from(new Uint8Array(encrypted)) })
-  localStorage.setItem(STORAGE_KEY, data)
+  const key = await getKey();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encrypted = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(apiKey),
+  );
+  const data = JSON.stringify({
+    iv: Array.from(iv),
+    data: Array.from(new Uint8Array(encrypted)),
+  });
+  localStorage.setItem(STORAGE_KEY, data);
 }
 
 export async function decryptFromStore(): Promise<string> {
-  const stored = localStorage.getItem(STORAGE_KEY)
-  if (!stored) return ''
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (!stored) return "";
   try {
-    const { iv, data } = JSON.parse(stored)
-    const key = await getKey()
-    const decrypted = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: new Uint8Array(iv) }, key, new Uint8Array(data))
-    return new TextDecoder().decode(decrypted)
+    const { iv, data } = JSON.parse(stored);
+    const key = await getKey();
+    const decrypted = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: new Uint8Array(iv) },
+      key,
+      new Uint8Array(data),
+    );
+    return new TextDecoder().decode(decrypted);
   } catch {
-    localStorage.removeItem(STORAGE_KEY)
-    return ''
+    localStorage.removeItem(STORAGE_KEY);
+    return "";
+  }
+}
+
+export async function encryptAndStoreHfToken(token: string): Promise<void> {
+  if (!token) {
+    localStorage.removeItem(HF_TOKEN_STORAGE_KEY);
+    return;
+  }
+
+  const key = await getHfTokenKey("encrypt");
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const encrypted = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    new TextEncoder().encode(token),
+  );
+  const payload = JSON.stringify({
+    iv: Array.from(iv),
+    data: Array.from(new Uint8Array(encrypted)),
+  });
+  localStorage.setItem(HF_TOKEN_STORAGE_KEY, payload);
+}
+
+export async function decryptHfTokenFromStore(): Promise<string> {
+  const stored = localStorage.getItem(HF_TOKEN_STORAGE_KEY);
+  if (!stored) return "";
+
+  try {
+    const { iv, data } = JSON.parse(stored);
+    const key = await getHfTokenKey("decrypt");
+    const decrypted = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: new Uint8Array(iv) },
+      key,
+      new Uint8Array(data),
+    );
+    return new TextDecoder().decode(decrypted);
+  } catch {
+    localStorage.removeItem(HF_TOKEN_STORAGE_KEY);
+    return "";
   }
 }


### PR DESCRIPTION
Add comprehensive API provider support to Flow mode, matching the functionality available in standard mode. 为 Flow 模式添加完整的 API 提供商支持，与标准模式功能保持一致。

Changes / 变更内容:
- Add API provider selection (Gitee AI, HF Z-Image, HF Qwen) to Flow page 在 Flow 页面添加 API 提供商选择（Gitee AI、HF Z-Image、HF Qwen）
- Integrate ApiConfigAccordion component for consistent API configuration 集成 ApiConfigAccordion 组件以实现统一的 API 配置
- Add HF Token encryption/decryption support for Flow mode 为 Flow 模式添加 HF Token 加密/解密支持
- Refactor crypto utilities to support separate HF Token storage 重构加密工具以支持独立的 HF Token 存储
- Update FloatingInput to support multiple API providers 更新 FloatingInput 以支持多个 API 提供商
- Sync API provider settings with localStorage for persistence 将 API 提供商设置与 localStorage 同步以实现持久化

This allows Flow mode users to leverage all available AI providers with proper token management and encrypted storage. 使 Flow 模式用户能够使用所有可用的 AI 提供商，并具有适当的令牌管理和加密存储功能。