### PR TITLE
chore(ci): simplify Dependabot config for monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,13 @@
 # Dependabot configuration
 # Keeps dependencies up-to-date and checks for security vulnerabilities
+#
+# Note: This is a pnpm monorepo - only monitor root package.json
+# Sub-packages share dependencies via workspace
 
 version: 2
 
 updates:
-  # Root package.json
+  # Root package.json only (monorepo manages all deps)
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -12,75 +15,34 @@ updates:
       day: 'monday'
       time: '09:00'
       timezone: 'Asia/Shanghai'
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     commit-message:
       prefix: 'chore(deps):'
     labels:
       - 'dependencies'
-      - 'chore'
     groups:
-      dev-dependencies:
+      # Group all minor/patch updates together
+      all-minor-patch:
         patterns:
-          - '@types/*'
-          - 'vitest'
-          - '@vitest/*'
-          - 'typescript'
-          - '@biomejs/*'
+          - '*'
         update-types:
           - 'minor'
           - 'patch'
-
-  # API package
-  - package-ecosystem: 'npm'
-    directory: '/apps/api'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '09:00'
-      timezone: 'Asia/Shanghai'
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: 'chore(deps-api):'
-    labels:
-      - 'dependencies'
-      - 'api'
-
-  # Web package
-  - package-ecosystem: 'npm'
-    directory: '/apps/web'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '09:00'
-      timezone: 'Asia/Shanghai'
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: 'chore(deps-web):'
-    labels:
-      - 'dependencies'
-      - 'web'
-    groups:
-      react:
-        patterns:
-          - 'react'
-          - 'react-dom'
-          - '@types/react*'
-      ui:
-        patterns:
-          - '@radix-ui/*'
-          - 'tailwindcss'
-          - '@tailwindcss/*'
 
   # GitHub Actions
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: 'monthly'
       time: '09:00'
       timezone: 'Asia/Shanghai'
+    open-pull-requests-limit: 3
     commit-message:
       prefix: 'chore(ci):'
     labels:
       - 'dependencies'
       - 'ci'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
- Remove separate monitoring for /apps/api and /apps/web
- Group all minor/patch updates into single PRs
- Reduce PR limits (npm: 5, actions: 3)
- Change GitHub Actions to monthly schedule

This reduces PR noise while maintaining security updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Brief description of changes -->

## Type of Change

<!-- Mark with [x] -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation
- [ ] `refactor`: Code refactoring
- [ ] `test`: Tests
- [ ] `chore`: Build/CI/dependencies

## Scope

<!-- Mark with [x] -->

- [ ] `api`: Backend API
- [ ] `web`: Frontend
- [ ] `shared`: Shared package
- [x] `ci`: GitHub Actions
- [ ] `deps`: Dependencies

## Checklist

- [ ] PR title follows format: `type(scope): description`
- [ ] Code passes `pnpm check`
- [ ] Tests pass `pnpm test:run`
- [ ] Documentation updated (if applicable)
- [ ] New tests added (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management and CI/CD configuration to streamline the release process and reduce automation overhead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->