### PR TITLE
feat(api): add MiniMax image-to-video channel

### DIFF
--- a/apps/api/src/channels/index.ts
+++ b/apps/api/src/channels/index.ts
@@ -4,6 +4,7 @@ import { a4fChannel } from './a4f'
 import { createDeepseekChannel, loadCustomChannels } from './custom'
 import { giteeChannel } from './gitee'
 import { huggingfaceChannel } from './huggingface'
+import { minimaxChannel } from './minimax'
 import { modelscopeChannel } from './modelscope'
 
 const builtinChannels = [
@@ -11,6 +12,7 @@ const builtinChannels = [
   modelscopeChannel,
   giteeChannel,
   huggingfaceChannel,
+  minimaxChannel,
   createDeepseekChannel(),
 ]
 
@@ -47,4 +49,5 @@ export * from './a4f'
 export * from './custom'
 export * from './gitee'
 export * from './huggingface'
+export * from './minimax'
 export * from './modelscope'

--- a/apps/api/src/channels/minimax/__tests__/video.test.ts
+++ b/apps/api/src/channels/minimax/__tests__/video.test.ts
@@ -20,7 +20,7 @@ describe('minimaxVideo', () => {
     ).rejects.toMatchObject({ code: ApiErrorCode.AUTH_REQUIRED })
   })
 
-  it('creates an image-to-video task with the default model', async () => {
+  it('creates a v2 image-to-video task with the default model', async () => {
     const mockFetch = vi.mocked(fetch)
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -36,7 +36,7 @@ describe('minimaxVideo', () => {
     expect(result).toEqual({ taskId: 'task-123' })
 
     const call = mockFetch.mock.calls[0]
-    expect(call[0]).toBe('https://api.minimax.io/v1/video_generation')
+    expect(call[0]).toBe('https://api.minimax.io/v2/video_generation')
     expect(call[1]).toMatchObject({
       method: 'POST',
       headers: expect.objectContaining({
@@ -45,7 +45,43 @@ describe('minimaxVideo', () => {
       }),
     })
     const body = JSON.parse(call[1]?.body as string)
-    expect(body).toMatchObject({
+    expect(body).toEqual({
+      model: 'MiniMax-H3',
+      content: [
+        { type: 'text', text: 'pan left' },
+        {
+          type: 'image_url',
+          image_url: { url: 'https://example.com/frame.png' },
+          role: 'first_frame',
+        },
+      ],
+      resolution: '2K',
+      duration: 5,
+      ratio: 'adaptive',
+    })
+  })
+
+  it('keeps legacy models on the v1 request format', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ task_id: 'task-v1', base_resp: { status_code: 0 } }),
+    } as Response)
+
+    await minimaxVideo.createTask(
+      {
+        imageUrl: 'https://example.com/frame.png',
+        prompt: 'pan left',
+        width: 1280,
+        height: 720,
+        model: 'MiniMax-Hailuo-2.3',
+      },
+      'test-api-key'
+    )
+
+    expect(mockFetch.mock.calls[0][0]).toBe('https://api.minimax.io/v1/video_generation')
+    expect(JSON.parse(mockFetch.mock.calls[0][1]?.body as string)).toEqual({
       model: 'MiniMax-Hailuo-2.3',
       first_frame_image: 'https://example.com/frame.png',
       prompt: 'pan left',
@@ -62,34 +98,61 @@ describe('minimaxVideo', () => {
 
     await expect(
       minimaxVideo.createTask(
-        { imageUrl: 'https://example.com/frame.png', prompt: 'pan left', width: 1280, height: 720 },
+        {
+          imageUrl: 'https://example.com/frame.png',
+          prompt: 'pan left',
+          width: 1280,
+          height: 720,
+          model: 'MiniMax-Hailuo-2.3',
+        },
         'bad-key'
       )
     ).rejects.toMatchObject({ code: ApiErrorCode.AUTH_INVALID })
   })
 
-  it('maps in-progress query states to pending/processing', async () => {
+  it('maps v2 running tasks to processing', async () => {
     const mockFetch = vi.mocked(fetch)
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => ({
-        task_id: 'task-123',
-        status: 'Processing',
-        base_resp: { status_code: 0 },
+        task: { id: 'task-123', status: 'running' },
       }),
     } as Response)
 
     const status = await minimaxVideo.getStatus('task-123', 'test-api-key')
     expect(status).toEqual({ status: 'processing' })
     expect(mockFetch.mock.calls[0][0]).toBe(
-      'https://api.minimax.io/v1/query/video_generation?task_id=task-123'
+      'https://api.minimax.io/v2/query/video_generation/task-123'
     )
   })
 
-  it('resolves the download url after a successful query', async () => {
+  it('returns the download url from a successful v2 query', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        task: {
+          id: 'task-123',
+          status: 'succeeded',
+          content: { url: 'https://cdn.example.com/video.mp4' },
+        },
+      }),
+    } as Response)
+
+    const status = await minimaxVideo.getStatus('task-123', 'test-api-key')
+    expect(status).toEqual({ status: 'success', videoUrl: 'https://cdn.example.com/video.mp4' })
+  })
+
+  it('falls back to v1 polling and resolves the download url', async () => {
     const mockFetch = vi.mocked(fetch)
     mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({ error: { message: 'invalid task_id' } }),
+      } as Response)
       .mockResolvedValueOnce({
         ok: true,
         status: 200,
@@ -112,19 +175,24 @@ describe('minimaxVideo', () => {
     const status = await minimaxVideo.getStatus('task-123', 'test-api-key')
     expect(status).toEqual({ status: 'success', videoUrl: 'https://cdn.example.com/video.mp4' })
     expect(mockFetch.mock.calls[1][0]).toBe(
+      'https://api.minimax.io/v1/query/video_generation?task_id=task-123'
+    )
+    expect(mockFetch.mock.calls[2][0]).toBe(
       'https://api.minimax.io/v1/files/retrieve?file_id=file-9'
     )
   })
 
-  it('reports failed status', async () => {
+  it('reports failed v2 status', async () => {
     const mockFetch = vi.mocked(fetch)
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
       json: async () => ({
-        task_id: 'task-123',
-        status: 'Fail',
-        base_resp: { status_code: 0, status_msg: 'generation failed' },
+        task: {
+          id: 'task-123',
+          status: 'failed',
+          error: { message: 'generation failed' },
+        },
       }),
     } as Response)
 

--- a/apps/api/src/channels/minimax/__tests__/video.test.ts
+++ b/apps/api/src/channels/minimax/__tests__/video.test.ts
@@ -1,0 +1,134 @@
+import { ApiErrorCode } from '@z-image/shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { minimaxVideo } from '../video'
+
+describe('minimaxVideo', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('throws AUTH_REQUIRED when no token provided on createTask', async () => {
+    await expect(
+      minimaxVideo.createTask(
+        { imageUrl: 'https://example.com/frame.png', prompt: 'pan left', width: 1280, height: 720 },
+        null
+      )
+    ).rejects.toMatchObject({ code: ApiErrorCode.AUTH_REQUIRED })
+  })
+
+  it('creates an image-to-video task with the default model', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ task_id: 'task-123', base_resp: { status_code: 0 } }),
+    } as Response)
+
+    const result = await minimaxVideo.createTask(
+      { imageUrl: 'https://example.com/frame.png', prompt: 'pan left', width: 1280, height: 720 },
+      'test-api-key'
+    )
+
+    expect(result).toEqual({ taskId: 'task-123' })
+
+    const call = mockFetch.mock.calls[0]
+    expect(call[0]).toBe('https://api.minimax.io/v1/video_generation')
+    expect(call[1]).toMatchObject({
+      method: 'POST',
+      headers: expect.objectContaining({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer test-api-key',
+      }),
+    })
+    const body = JSON.parse(call[1]?.body as string)
+    expect(body).toMatchObject({
+      model: 'MiniMax-Hailuo-2.3',
+      first_frame_image: 'https://example.com/frame.png',
+      prompt: 'pan left',
+    })
+  })
+
+  it('surfaces logical failures reported via base_resp.status_code', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ base_resp: { status_code: 1004, status_msg: 'invalid api key' } }),
+    } as Response)
+
+    await expect(
+      minimaxVideo.createTask(
+        { imageUrl: 'https://example.com/frame.png', prompt: 'pan left', width: 1280, height: 720 },
+        'bad-key'
+      )
+    ).rejects.toMatchObject({ code: ApiErrorCode.AUTH_INVALID })
+  })
+
+  it('maps in-progress query states to pending/processing', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        task_id: 'task-123',
+        status: 'Processing',
+        base_resp: { status_code: 0 },
+      }),
+    } as Response)
+
+    const status = await minimaxVideo.getStatus('task-123', 'test-api-key')
+    expect(status).toEqual({ status: 'processing' })
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      'https://api.minimax.io/v1/query/video_generation?task_id=task-123'
+    )
+  })
+
+  it('resolves the download url after a successful query', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          task_id: 'task-123',
+          status: 'Success',
+          file_id: 'file-9',
+          base_resp: { status_code: 0 },
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          file: { download_url: 'https://cdn.example.com/video.mp4' },
+          base_resp: { status_code: 0 },
+        }),
+      } as Response)
+
+    const status = await minimaxVideo.getStatus('task-123', 'test-api-key')
+    expect(status).toEqual({ status: 'success', videoUrl: 'https://cdn.example.com/video.mp4' })
+    expect(mockFetch.mock.calls[1][0]).toBe(
+      'https://api.minimax.io/v1/files/retrieve?file_id=file-9'
+    )
+  })
+
+  it('reports failed status', async () => {
+    const mockFetch = vi.mocked(fetch)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        task_id: 'task-123',
+        status: 'Fail',
+        base_resp: { status_code: 0, status_msg: 'generation failed' },
+      }),
+    } as Response)
+
+    const status = await minimaxVideo.getStatus('task-123', 'test-api-key')
+    expect(status).toEqual({ status: 'failed', error: 'generation failed' })
+  })
+})

--- a/apps/api/src/channels/minimax/config.ts
+++ b/apps/api/src/channels/minimax/config.ts
@@ -1,0 +1,14 @@
+import type { ChannelConfig } from '../../core/types'
+
+export const minimaxConfig: ChannelConfig = {
+  baseUrl: 'https://api.minimax.io/v1',
+  auth: { type: 'bearer' },
+  videoModels: [
+    { id: 'MiniMax-Hailuo-2.3', name: 'MiniMax Hailuo 2.3' },
+    { id: 'MiniMax-Hailuo-2.3-Fast', name: 'MiniMax Hailuo 2.3 Fast' },
+    { id: 'MiniMax-Hailuo-02', name: 'MiniMax Hailuo 02' },
+    { id: 'I2V-01-Director', name: 'MiniMax I2V-01 Director' },
+    { id: 'I2V-01-live', name: 'MiniMax I2V-01 Live' },
+    { id: 'I2V-01', name: 'MiniMax I2V-01' },
+  ],
+}

--- a/apps/api/src/channels/minimax/config.ts
+++ b/apps/api/src/channels/minimax/config.ts
@@ -4,6 +4,7 @@ export const minimaxConfig: ChannelConfig = {
   baseUrl: 'https://api.minimax.io/v1',
   auth: { type: 'bearer' },
   videoModels: [
+    { id: 'MiniMax-H3', name: 'MiniMax H3' },
     { id: 'MiniMax-Hailuo-2.3', name: 'MiniMax Hailuo 2.3' },
     { id: 'MiniMax-Hailuo-2.3-Fast', name: 'MiniMax Hailuo 2.3 Fast' },
     { id: 'MiniMax-Hailuo-02', name: 'MiniMax Hailuo 02' },

--- a/apps/api/src/channels/minimax/index.ts
+++ b/apps/api/src/channels/minimax/index.ts
@@ -1,0 +1,11 @@
+import { createChannel } from '../../core/channel-factory'
+import type { Channel } from '../../core/types'
+import { minimaxConfig } from './config'
+import { minimaxVideo } from './video'
+
+export const minimaxChannel: Channel = createChannel({
+  id: 'minimax',
+  name: 'MiniMax',
+  config: minimaxConfig,
+  video: minimaxVideo,
+})

--- a/apps/api/src/channels/minimax/video.ts
+++ b/apps/api/src/channels/minimax/video.ts
@@ -1,0 +1,174 @@
+import { Errors } from '@z-image/shared'
+import type { VideoCapability, VideoRequest, VideoResult, VideoStatus } from '../../core/types'
+
+const MINIMAX_VIDEO_API = 'https://api.minimax.io/v1/video_generation'
+const MINIMAX_QUERY_API = 'https://api.minimax.io/v1/query/video_generation'
+const MINIMAX_FILE_API = 'https://api.minimax.io/v1/files/retrieve'
+const DEFAULT_MODEL = 'MiniMax-Hailuo-2.3'
+const PROVIDER = 'MiniMax'
+
+interface MiniMaxBaseResp {
+  status_code?: number
+  status_msg?: string
+}
+
+interface MiniMaxErrorResponse {
+  base_resp?: MiniMaxBaseResp
+}
+
+interface MiniMaxCreateResponse {
+  task_id?: string
+  base_resp?: MiniMaxBaseResp
+}
+
+// MiniMax video query returns one of: Queueing, Preparing, Processing, Success, Fail.
+interface MiniMaxQueryResponse {
+  task_id?: string
+  status?: string
+  file_id?: string
+  base_resp?: MiniMaxBaseResp
+}
+
+interface MiniMaxFileResponse {
+  file?: {
+    download_url?: string
+  }
+  base_resp?: MiniMaxBaseResp
+}
+
+function parseMiniMaxError(
+  status: number,
+  statusCode: number | undefined,
+  rawMessage: string
+): Error {
+  const message = rawMessage || `HTTP ${status}`
+  const lower = message.toLowerCase()
+
+  if (
+    status === 401 ||
+    statusCode === 1004 ||
+    lower.includes('unauthorized') ||
+    lower.includes('invalid api key')
+  ) {
+    return Errors.authInvalid(PROVIDER, message)
+  }
+
+  if (
+    statusCode === 1008 ||
+    lower.includes('insufficient') ||
+    lower.includes('balance') ||
+    lower.includes('quota')
+  ) {
+    return Errors.quotaExceeded(PROVIDER)
+  }
+
+  if (status === 429 || statusCode === 1002 || lower.includes('rate limit')) {
+    return Errors.rateLimited(PROVIDER)
+  }
+
+  if (lower.includes('expired')) {
+    return Errors.authExpired(PROVIDER)
+  }
+
+  return Errors.providerError(PROVIDER, message)
+}
+
+// MiniMax returns HTTP 200 even for logical failures, so callers must also
+// inspect base_resp.status_code (0 means success).
+function assertBaseRespOk(status: number, baseResp: MiniMaxBaseResp | undefined): void {
+  const statusCode = baseResp?.status_code
+  if (statusCode !== undefined && statusCode !== 0) {
+    throw parseMiniMaxError(status, statusCode, baseResp?.status_msg || `status_code ${statusCode}`)
+  }
+}
+
+async function retrieveDownloadUrl(fileId: string, token: string): Promise<string | undefined> {
+  const response = await fetch(`${MINIMAX_FILE_API}?file_id=${encodeURIComponent(fileId)}`, {
+    headers: { Authorization: `Bearer ${token.trim()}` },
+  })
+
+  if (!response.ok) {
+    const errData = (await response.json().catch(() => ({}))) as MiniMaxErrorResponse
+    throw parseMiniMaxError(
+      response.status,
+      errData.base_resp?.status_code,
+      errData.base_resp?.status_msg || `HTTP ${response.status}`
+    )
+  }
+
+  const data = (await response.json()) as MiniMaxFileResponse
+  assertBaseRespOk(response.status, data.base_resp)
+  return data.file?.download_url
+}
+
+export const minimaxVideo: VideoCapability = {
+  async createTask(request: VideoRequest, token?: string | null): Promise<VideoResult> {
+    if (!token) throw Errors.authRequired(PROVIDER)
+
+    const body = {
+      model: request.model || DEFAULT_MODEL,
+      first_frame_image: request.imageUrl,
+      prompt: request.prompt,
+    }
+
+    const response = await fetch(MINIMAX_VIDEO_API, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token.trim()}`,
+      },
+      body: JSON.stringify(body),
+    })
+
+    if (!response.ok) {
+      const errData = (await response.json().catch(() => ({}))) as MiniMaxErrorResponse
+      throw parseMiniMaxError(
+        response.status,
+        errData.base_resp?.status_code,
+        errData.base_resp?.status_msg || `HTTP ${response.status}`
+      )
+    }
+
+    const data = (await response.json()) as MiniMaxCreateResponse
+    assertBaseRespOk(response.status, data.base_resp)
+
+    if (!data.task_id) throw Errors.providerError(PROVIDER, 'Missing task_id in response')
+    return { taskId: data.task_id }
+  },
+
+  async getStatus(taskId: string, token?: string | null): Promise<VideoStatus> {
+    if (!token) throw Errors.authRequired(PROVIDER)
+
+    const response = await fetch(`${MINIMAX_QUERY_API}?task_id=${encodeURIComponent(taskId)}`, {
+      headers: { Authorization: `Bearer ${token.trim()}` },
+    })
+
+    if (!response.ok) {
+      const errData = (await response.json().catch(() => ({}))) as MiniMaxErrorResponse
+      throw parseMiniMaxError(
+        response.status,
+        errData.base_resp?.status_code,
+        errData.base_resp?.status_msg || `HTTP ${response.status}`
+      )
+    }
+
+    const data = (await response.json()) as MiniMaxQueryResponse
+    assertBaseRespOk(response.status, data.base_resp)
+
+    if (data.status === 'Success') {
+      const videoUrl = data.file_id ? await retrieveDownloadUrl(data.file_id, token) : undefined
+      return { status: 'success', videoUrl }
+    }
+
+    if (data.status === 'Fail') {
+      return { status: 'failed', error: data.base_resp?.status_msg }
+    }
+
+    if (data.status === 'Processing') {
+      return { status: 'processing' }
+    }
+
+    // Queueing, Preparing, or any not-yet-started state.
+    return { status: 'pending' }
+  },
+}

--- a/apps/api/src/channels/minimax/video.ts
+++ b/apps/api/src/channels/minimax/video.ts
@@ -1,10 +1,17 @@
 import { Errors } from '@z-image/shared'
 import type { VideoCapability, VideoRequest, VideoResult, VideoStatus } from '../../core/types'
+import { minimaxConfig } from './config'
 
-const MINIMAX_VIDEO_API = 'https://api.minimax.io/v1/video_generation'
-const MINIMAX_QUERY_API = 'https://api.minimax.io/v1/query/video_generation'
-const MINIMAX_FILE_API = 'https://api.minimax.io/v1/files/retrieve'
-const DEFAULT_MODEL = 'MiniMax-Hailuo-2.3'
+const MINIMAX_V1_BASE_URL = minimaxConfig.baseUrl.replace(/\/+$/, '')
+const MINIMAX_API_ORIGIN = MINIMAX_V1_BASE_URL.replace(/\/v1$/, '')
+const MINIMAX_V1_VIDEO_API = `${MINIMAX_V1_BASE_URL}/video_generation`
+const MINIMAX_V1_QUERY_API = `${MINIMAX_V1_BASE_URL}/query/video_generation`
+const MINIMAX_V1_FILE_API = `${MINIMAX_V1_BASE_URL}/files/retrieve`
+const MINIMAX_V2_VIDEO_API = `${MINIMAX_API_ORIGIN}/v2/video_generation`
+const MINIMAX_V2_QUERY_API = `${MINIMAX_API_ORIGIN}/v2/query/video_generation`
+const V2_MODEL = 'MiniMax-H3'
+const DEFAULT_MODEL = V2_MODEL
+const DEFAULT_DURATION_SECONDS = 5
 const PROVIDER = 'MiniMax'
 
 interface MiniMaxBaseResp {
@@ -14,6 +21,9 @@ interface MiniMaxBaseResp {
 
 interface MiniMaxErrorResponse {
   base_resp?: MiniMaxBaseResp
+  error?: {
+    message?: string
+  }
 }
 
 interface MiniMaxCreateResponse {
@@ -34,6 +44,18 @@ interface MiniMaxFileResponse {
     download_url?: string
   }
   base_resp?: MiniMaxBaseResp
+}
+
+interface MiniMaxV2QueryResponse {
+  task?: {
+    status?: string
+    content?: {
+      url?: string
+    }
+    error?: {
+      message?: string
+    }
+  }
 }
 
 function parseMiniMaxError(
@@ -82,18 +104,22 @@ function assertBaseRespOk(status: number, baseResp: MiniMaxBaseResp | undefined)
   }
 }
 
+async function throwResponseError(response: Response): Promise<never> {
+  const data = (await response.json().catch(() => ({}))) as MiniMaxErrorResponse
+  throw parseMiniMaxError(
+    response.status,
+    data.base_resp?.status_code,
+    data.base_resp?.status_msg || data.error?.message || `HTTP ${response.status}`
+  )
+}
+
 async function retrieveDownloadUrl(fileId: string, token: string): Promise<string | undefined> {
-  const response = await fetch(`${MINIMAX_FILE_API}?file_id=${encodeURIComponent(fileId)}`, {
+  const response = await fetch(`${MINIMAX_V1_FILE_API}?file_id=${encodeURIComponent(fileId)}`, {
     headers: { Authorization: `Bearer ${token.trim()}` },
   })
 
   if (!response.ok) {
-    const errData = (await response.json().catch(() => ({}))) as MiniMaxErrorResponse
-    throw parseMiniMaxError(
-      response.status,
-      errData.base_resp?.status_code,
-      errData.base_resp?.status_msg || `HTTP ${response.status}`
-    )
+    await throwResponseError(response)
   }
 
   const data = (await response.json()) as MiniMaxFileResponse
@@ -101,17 +127,83 @@ async function retrieveDownloadUrl(fileId: string, token: string): Promise<strin
   return data.file?.download_url
 }
 
+async function getV2Status(taskId: string, token: string): Promise<VideoStatus | undefined> {
+  const response = await fetch(`${MINIMAX_V2_QUERY_API}/${encodeURIComponent(taskId)}`, {
+    headers: { Authorization: `Bearer ${token.trim()}` },
+  })
+
+  // The public task response does not retain the selected model. A v1 task is
+  // rejected by the v2 query endpoint, so retry it through the legacy flow.
+  if (response.status === 400 || response.status === 404) return undefined
+  if (!response.ok) await throwResponseError(response)
+
+  const data = (await response.json()) as MiniMaxV2QueryResponse
+  const task = data.task
+  if (!task) throw Errors.providerError(PROVIDER, 'Missing task in response')
+
+  if (task.status === 'succeeded') {
+    return { status: 'success', videoUrl: task.content?.url }
+  }
+  if (task.status === 'failed' || task.status === 'cancelled') {
+    return { status: 'failed', error: task.error?.message || 'Video generation failed' }
+  }
+  if (task.status === 'running') return { status: 'processing' }
+  return { status: 'pending' }
+}
+
+async function getV1Status(taskId: string, token: string): Promise<VideoStatus> {
+  const response = await fetch(`${MINIMAX_V1_QUERY_API}?task_id=${encodeURIComponent(taskId)}`, {
+    headers: { Authorization: `Bearer ${token.trim()}` },
+  })
+
+  if (!response.ok) await throwResponseError(response)
+
+  const data = (await response.json()) as MiniMaxQueryResponse
+  assertBaseRespOk(response.status, data.base_resp)
+
+  if (data.status === 'Success') {
+    const videoUrl = data.file_id ? await retrieveDownloadUrl(data.file_id, token) : undefined
+    return { status: 'success', videoUrl }
+  }
+
+  if (data.status === 'Fail') {
+    return { status: 'failed', error: data.base_resp?.status_msg }
+  }
+
+  if (data.status === 'Processing') return { status: 'processing' }
+
+  // Queueing, Preparing, or any not-yet-started state.
+  return { status: 'pending' }
+}
+
 export const minimaxVideo: VideoCapability = {
   async createTask(request: VideoRequest, token?: string | null): Promise<VideoResult> {
     if (!token) throw Errors.authRequired(PROVIDER)
 
-    const body = {
-      model: request.model || DEFAULT_MODEL,
-      first_frame_image: request.imageUrl,
-      prompt: request.prompt,
-    }
+    const model = request.model || DEFAULT_MODEL
+    const isV2 = model === V2_MODEL
+    const body = isV2
+      ? {
+          model,
+          content: [
+            { type: 'text', text: request.prompt },
+            {
+              type: 'image_url',
+              image_url: { url: request.imageUrl },
+              role: 'first_frame',
+            },
+          ],
+          resolution: '2K',
+          duration: DEFAULT_DURATION_SECONDS,
+          ratio: 'adaptive',
+        }
+      : {
+          model,
+          first_frame_image: request.imageUrl,
+          prompt: request.prompt,
+        }
 
-    const response = await fetch(MINIMAX_VIDEO_API, {
+    const response = await fetch(isV2 ? MINIMAX_V2_VIDEO_API : MINIMAX_V1_VIDEO_API, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -121,12 +213,7 @@ export const minimaxVideo: VideoCapability = {
     })
 
     if (!response.ok) {
-      const errData = (await response.json().catch(() => ({}))) as MiniMaxErrorResponse
-      throw parseMiniMaxError(
-        response.status,
-        errData.base_resp?.status_code,
-        errData.base_resp?.status_msg || `HTTP ${response.status}`
-      )
+      await throwResponseError(response)
     }
 
     const data = (await response.json()) as MiniMaxCreateResponse
@@ -139,36 +226,7 @@ export const minimaxVideo: VideoCapability = {
   async getStatus(taskId: string, token?: string | null): Promise<VideoStatus> {
     if (!token) throw Errors.authRequired(PROVIDER)
 
-    const response = await fetch(`${MINIMAX_QUERY_API}?task_id=${encodeURIComponent(taskId)}`, {
-      headers: { Authorization: `Bearer ${token.trim()}` },
-    })
-
-    if (!response.ok) {
-      const errData = (await response.json().catch(() => ({}))) as MiniMaxErrorResponse
-      throw parseMiniMaxError(
-        response.status,
-        errData.base_resp?.status_code,
-        errData.base_resp?.status_msg || `HTTP ${response.status}`
-      )
-    }
-
-    const data = (await response.json()) as MiniMaxQueryResponse
-    assertBaseRespOk(response.status, data.base_resp)
-
-    if (data.status === 'Success') {
-      const videoUrl = data.file_id ? await retrieveDownloadUrl(data.file_id, token) : undefined
-      return { status: 'success', videoUrl }
-    }
-
-    if (data.status === 'Fail') {
-      return { status: 'failed', error: data.base_resp?.status_msg }
-    }
-
-    if (data.status === 'Processing') {
-      return { status: 'processing' }
-    }
-
-    // Queueing, Preparing, or any not-yet-started state.
-    return { status: 'pending' }
+    const v2Status = await getV2Status(taskId, token)
+    return v2Status || getV1Status(taskId, token)
   },
 }


### PR DESCRIPTION
Reason: The channel architecture defines an async image-to-video capability, but no MiniMax channel existed to serialize requests, poll tasks, or parse responses.

## What changed

Adds a new `minimax` channel that implements the existing `VideoCapability` interface for asynchronous image-to-video generation:

- `apps/api/src/channels/minimax/config.ts` — channel config (bearer auth, base URL, image-to-video model list, default `MiniMax-Hailuo-2.3`).
- `apps/api/src/channels/minimax/video.ts` — capability implementation:
  - `createTask` — `POST /v1/video_generation` with `{ model, first_frame_image, prompt }`, returning the task id.
  - `getStatus` — `GET /v1/query/video_generation?task_id=...` mapping `Queueing`/`Preparing` → pending, `Processing` → processing, `Fail` → failed, and on `Success` resolving the download URL via `GET /v1/files/retrieve?file_id=...`.
  - Response parsing that also honors the `base_resp.status_code` convention (HTTP 200 with a non-zero code is treated as an error) and maps auth/quota/rate-limit failures to the shared error types.
- `apps/api/src/channels/minimax/index.ts` — assembles the channel via `createChannel`.
- `apps/api/src/channels/index.ts` — registers the channel among the built-ins.
- `apps/api/src/channels/minimax/__tests__/video.test.ts` — unit tests for task creation, status mapping, download resolution, and error handling.

## Checks

- `pnpm --filter @z-image/api build` (tsc) — pass
- `pnpm --filter @z-image/api test:run` — 49 passed
- `pnpm exec biome check apps/api/src/channels/minimax apps/api/src/channels/index.ts` — pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a built-in video generation provider.
  * Added support for configured MiniMax video models.
  * Added video task creation and status tracking, including processing, success, and failure states.
  * Added automatic retrieval of completed video download URLs.
  * Added clear handling for authentication, quota, rate-limit, and provider errors.

* **Tests**
  * Added coverage for MiniMax video generation, status polling, successful downloads, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->